### PR TITLE
add nullPrototype option, improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ deepmerge(options)
 
 - `symbols` (`boolean`, optional) - should also merge object-keys which are symbols, default is false
 - `all` (`boolean`, optional) - merges all parameters, default is false
-- `nullPrototype` (`boolean, optional) - created Objects have no prototype so keys like constructor and prototype are allowed without having the risk of a prototype pollution but has a ca. 20 % performance penalty, default is false
+- `nullPrototype` (`boolean, optional) - created Objects have no prototype so keys like constructor and prototype are allowed without having the risk of a prototype pollution but has a ca. 20-30 % performance penalty, default is false
 
 ```js
 const deepmerge = require('@fastify/deepmegre')()
@@ -43,32 +43,32 @@ The benchmarks are available in the benchmark-folder.
 
 `npm run bench` - benchmark various use cases of deepmerge:
 ```
-@fastify/deepmerge: merge regex with date x 1,266,447,885 ops/sec ±0.14% (97 runs sampled)
-@fastify/deepmerge: merge object with a primitive x 1,266,435,016 ops/sec ±0.33% (97 runs sampled)
-@fastify/deepmerge: merge two arrays containing strings x 25,591,739 ops/sec ±0.24% (98 runs sampled)
-@fastify/deepmerge: two merge arrays containing objects x 976,182 ops/sec ±0.46% (98 runs sampled)
-@fastify/deepmerge: merge two flat objects x 10,027,879 ops/sec ±0.36% (94 runs sampled)
-@fastify/deepmerge: merge nested objects x 5,341,227 ops/sec ±0.67% (94 runs sampled)
+@fastify/deepmerge: merge regex with date x 1,218,057,587 ops/sec ±0.42% (92 runs sampled)
+@fastify/deepmerge: merge object with a primitive x 1,227,135,062 ops/sec ±0.55% (95 runs sampled)
+@fastify/deepmerge: merge two arrays containing strings x 24,189,601 ops/sec ±0.81% (94 runs sampled)
+@fastify/deepmerge: merge two arrays containing objects x 1,484,734 ops/sec ±0.45% (90 runs sampled)
+@fastify/deepmerge: merge two flat objects x 13,058,801 ops/sec ±0.60% (95 runs sampled)
+@fastify/deepmerge: merge nested objects x 6,268,848 ops/sec ±0.43% (97 runs sampled)
 ```
 
-`npm run bench:nullprototype` - benchmark various use cases of deepmerge:
+`npm run bench:nullprototype` - benchmark deepmerge with nullPrototype set to true:
 ```
-@fastify/deepmerge: merge regex with date x 1,256,395,320 ops/sec ±0.21% (99 runs sampled)
-@fastify/deepmerge: merge object with a primitive x 1,257,949,819 ops/sec ±0.20% (93 runs sampled)
-@fastify/deepmerge: merge two arrays containing strings x 25,051,036 ops/sec ±0.57% (94 runs sampled)
-@fastify/deepmerge: two merge arrays containing objects x 942,037 ops/sec ±0.43% (95 runs sampled)
-@fastify/deepmerge: merge two flat objects x 7,881,518 ops/sec ±0.64% (92 runs sampled)
-@fastify/deepmerge: merge nested objects x 4,751,207 ops/sec ±0.70% (95 runs sampled)
+@fastify/deepmerge: merge regex with date x 1,268,527,098 ops/sec ±0.12% (98 runs sampled)
+@fastify/deepmerge: merge object with a primitive x 1,276,444,240 ops/sec ±0.10% (98 runs sampled)
+@fastify/deepmerge: merge two arrays containing strings x 25,685,858 ops/sec ±0.24% (98 runs sampled)
+@fastify/deepmerge: merge two arrays containing objects x 1,572,714 ops/sec ±0.89% (96 runs sampled)
+@fastify/deepmerge: merge two flat objects x 10,009,494 ops/sec ±0.83% (89 runs sampled)
+@fastify/deepmerge: merge nested objects x 6,349,727 ops/sec ±0.66% (96 runs sampled)
 ```
 
 `npm run bench:compare` - comparison of @fastify/deepmerge with other popular deepmerge implementation:
 ```
-@fastify/deepmerge x 403,777 ops/sec ±0.22% (98 runs sampled)
-deepmerge x 21,143 ops/sec ±0.83% (93 runs sampled)
-merge-deep x 89,447 ops/sec ±0.59% (95 runs sampled)
-ts-deepmerge x 185,601 ops/sec ±0.59% (96 runs sampled)
-deepmerge-ts x 185,310 ops/sec ±0.50% (92 runs sampled)
-lodash.merge x 89,053 ops/sec ±0.37% (99 runs sampled)
+@fastify/deepmerge x 569,163 ops/sec ±0.20% (100 runs sampled)
+deepmerge x 21,584 ops/sec ±0.65% (96 runs sampled)
+merge-deep x 89,263 ops/sec ±0.47% (99 runs sampled)
+ts-deepmerge x 186,674 ops/sec ±0.54% (92 runs sampled)
+deepmerge-ts x 184,958 ops/sec ±0.17% (96 runs sampled)
+lodash.merge x 90,968 ops/sec ±0.35% (95 runs sampled)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ deepmerge(options)
 
 - `symbols` (`boolean`, optional) - should also merge object-keys which are symbols, default is false
 - `all` (`boolean`, optional) - merges all parameters, default is false
+- `nullPrototype` (`boolean, optional) - created Objects have no prototype so keys like constructor and prototype are allowed without having the risk of a prototype pollution but has a ca. 20 % performance penalty, default is false
 
 ```js
 const deepmerge = require('@fastify/deepmegre')()
@@ -48,6 +49,16 @@ The benchmarks are available in the benchmark-folder.
 @fastify/deepmerge: two merge arrays containing objects x 976,182 ops/sec ±0.46% (98 runs sampled)
 @fastify/deepmerge: merge two flat objects x 10,027,879 ops/sec ±0.36% (94 runs sampled)
 @fastify/deepmerge: merge nested objects x 5,341,227 ops/sec ±0.67% (94 runs sampled)
+```
+
+`npm run bench:nullprototype` - benchmark various use cases of deepmerge:
+```
+@fastify/deepmerge: merge regex with date x 1,256,395,320 ops/sec ±0.21% (99 runs sampled)
+@fastify/deepmerge: merge object with a primitive x 1,257,949,819 ops/sec ±0.20% (93 runs sampled)
+@fastify/deepmerge: merge two arrays containing strings x 25,051,036 ops/sec ±0.57% (94 runs sampled)
+@fastify/deepmerge: two merge arrays containing objects x 942,037 ops/sec ±0.43% (95 runs sampled)
+@fastify/deepmerge: merge two flat objects x 7,881,518 ops/sec ±0.64% (92 runs sampled)
+@fastify/deepmerge: merge nested objects x 4,751,207 ops/sec ±0.70% (95 runs sampled)
 ```
 
 `npm run bench:compare` - comparison of @fastify/deepmerge with other popular deepmerge implementation:

--- a/benchmark/bench.all.js
+++ b/benchmark/bench.all.js
@@ -38,7 +38,7 @@ new Benchmark.Suite()
   .add('@fastify/deepmerge: merge two arrays containing strings', function () {
     deepmerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('@fastify/deepmerge: two merge arrays containing objects', function () {
+  .add('@fastify/deepmerge: merge two arrays containing objects', function () {
     deepmerge(complexArrayTarget, complexArraySource)
   })
   .add('@fastify/deepmerge: merge two flat objects', function () {

--- a/benchmark/bench.compare.detailed.js
+++ b/benchmark/bench.compare.detailed.js
@@ -43,7 +43,7 @@ new Benchmark.Suite()
   .add('@fastify/deepmerge: merge two arrays containing strings', function () {
     fastifyDeepmerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('@fastify/deepmerge: two merge arrays containing objects', function () {
+  .add('@fastify/deepmerge: merge two arrays containing objects', function () {
     fastifyDeepmerge(complexArrayTarget, complexArraySource)
   })
   .add('@fastify/deepmerge: merge two flat objects', function () {
@@ -61,7 +61,7 @@ new Benchmark.Suite()
   .add('deepmerge: merge two arrays containing strings', function () {
     deepmerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('deepmerge: two merge arrays containing objects', function () {
+  .add('deepmerge: merge two arrays containing objects', function () {
     deepmerge(complexArrayTarget, complexArraySource)
   })
   .add('deepmerge: merge two flat objects', function () {
@@ -79,7 +79,7 @@ new Benchmark.Suite()
   .add('merge-deep: merge two arrays containing strings', function () {
     mergedeep(simpleArrayTarget, simpleArraySource)
   })
-  .add('merge-deep: two merge arrays containing objects', function () {
+  .add('merge-deep: merge two arrays containing objects', function () {
     mergedeep(complexArrayTarget, complexArraySource)
   })
   .add('merge-deep: merge two flat objects', function () {
@@ -97,7 +97,7 @@ new Benchmark.Suite()
   .add('ts-deepmerge: merge two arrays containing strings', function () {
     tsDeepmerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('ts-deepmerge: two merge arrays containing objects', function () {
+  .add('ts-deepmerge: merge two arrays containing objects', function () {
     tsDeepmerge(complexArrayTarget, complexArraySource)
   })
   .add('ts-deepmerge: merge two flat objects', function () {
@@ -115,7 +115,7 @@ new Benchmark.Suite()
   .add('deepmerge-ts: merge two arrays containing strings', function () {
     deepmergeTs(simpleArrayTarget, simpleArraySource)
   })
-  .add('deepmerge-ts: two merge arrays containing objects', function () {
+  .add('deepmerge-ts: merge two arrays containing objects', function () {
     deepmergeTs(complexArrayTarget, complexArraySource)
   })
   .add('deepmerge-ts: merge two flat objects', function () {
@@ -133,7 +133,7 @@ new Benchmark.Suite()
   .add('lodash.merge: merge two arrays containing strings', function () {
     lodashMerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('lodash.merge: two merge arrays containing objects', function () {
+  .add('lodash.merge: merge two arrays containing objects', function () {
     lodashMerge(complexArrayTarget, complexArraySource)
   })
   .add('lodash.merge: merge two flat objects', function () {

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -38,7 +38,7 @@ new Benchmark.Suite()
   .add('@fastify/deepmerge: merge two arrays containing strings', function () {
     deepmerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('@fastify/deepmerge: two merge arrays containing objects', function () {
+  .add('@fastify/deepmerge: merge two arrays containing objects', function () {
     deepmerge(complexArrayTarget, complexArraySource)
   })
   .add('@fastify/deepmerge: merge two flat objects', function () {

--- a/benchmark/bench.nullPrototype.js
+++ b/benchmark/bench.nullPrototype.js
@@ -38,7 +38,7 @@ new Benchmark.Suite()
   .add('@fastify/deepmerge: merge two arrays containing strings', function () {
     deepmerge(simpleArrayTarget, simpleArraySource)
   })
-  .add('@fastify/deepmerge: two merge arrays containing objects', function () {
+  .add('@fastify/deepmerge: merge two arrays containing objects', function () {
     deepmerge(complexArrayTarget, complexArraySource)
   })
   .add('@fastify/deepmerge: merge two flat objects', function () {

--- a/benchmark/bench.nullPrototype.js
+++ b/benchmark/bench.nullPrototype.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const Benchmark = require('benchmark')
+const deepmerge = require('..')({ nullPrototype: true })
+
+const sourceSimple = { key1: 'changed', key2: 'value2' }
+const targetSimple = { key1: 'value1', key3: 'value3' }
+
+const sourceNested = {
+  key1: {
+    subkey1: 'subvalue1',
+    subkey2: 'subvalue2'
+  }
+}
+const targetNested = {
+  key1: 'value1',
+  key2: 'value2'
+}
+
+const primitive = 'primitive'
+
+const date = new Date()
+const regex = /a/g
+
+const simpleArrayTarget = ['a1', 'a2', 'c1', 'f1', 'p1']
+const simpleArraySource = ['t1', 's1', 'c2', 'r1', 'p2', 'p3']
+
+const complexArraySource = [{ ...sourceSimple }, { ...sourceSimple }, { ...sourceSimple }, { ...sourceSimple }, { ...sourceSimple }]
+const complexArrayTarget = [{ ...targetSimple }, { ...targetSimple }, { ...targetSimple }, { ...targetSimple }, { ...targetSimple }]
+
+new Benchmark.Suite()
+  .add('@fastify/deepmerge: merge regex with date', function () {
+    deepmerge(regex, date)
+  })
+  .add('@fastify/deepmerge: merge object with a primitive', function () {
+    deepmerge(targetSimple, primitive)
+  })
+  .add('@fastify/deepmerge: merge two arrays containing strings', function () {
+    deepmerge(simpleArrayTarget, simpleArraySource)
+  })
+  .add('@fastify/deepmerge: two merge arrays containing objects', function () {
+    deepmerge(complexArrayTarget, complexArraySource)
+  })
+  .add('@fastify/deepmerge: merge two flat objects', function () {
+    deepmerge(targetSimple, sourceSimple)
+  })
+  .add('@fastify/deepmerge: merge nested objects', function () {
+    deepmerge(targetNested, sourceNested)
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .run()

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,7 +8,8 @@
     "bench": "node ./bench.js",
     "bench:all": "node ./bench.all.js",
     "bench:compare": "node ./bench.compare.js",
-    "bench:compare:detailed": "node ./bench.compare.detailed.js"
+    "bench:compare:detailed": "node ./bench.compare.detailed.js",
+    "bench:nullprototype": "node ./bench.nullPrototype.js"
   },
   "author": "",
   "license": "ISC",

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function deepmergeConstructor (options) {
     return isMergeableObject(entry)
       ? Array.isArray(entry)
         ? cloneArray(entry)
-        : mergeObject({}, entry)
+        : cloneObject(entry)
       : entry
   }
 
@@ -97,23 +97,52 @@ function deepmergeConstructor (options) {
     return result
   }
 
-  function mergeObjectWithPrototype (target, source) {
-    const targetKeys = getKeys(target)
-    const sourceKeys = getKeys(source)
+  function cloneObjectWithPrototype (target) {
     const result = {}
+
+    const targetKeys = getKeys(target)
     let i, il, key
     for (i = 0, il = targetKeys.length; i < il; ++i) {
       isNotPrototypeKey(key = targetKeys[i]) &&
-        (sourceKeys.indexOf(key) === -1) &&
         (result[key] = clone(target[key]))
+    }
+    return result
+  }
+
+  function cloneObjectNullPrototype (target) {
+    const result = Object.create(null)
+
+    const targetKeys = getKeys(target)
+    let i, il, key
+    for (i = 0, il = targetKeys.length; i < il; ++i) {
+      key = targetKeys[i]
+      result[key] = clone(target[key])
+    }
+    return result
+  }
+
+  const cloneObject = options && options.nullPrototype === true
+    ? cloneObjectNullPrototype
+    : cloneObjectWithPrototype
+
+  function mergeObjectWithPrototype (target, source) {
+    const result = {}
+
+    const targetKeys = getKeys(target)
+    const sourceKeys = getKeys(source)
+    let i, il, key
+    for (i = 0, il = targetKeys.length; i < il; ++i) {
+      isNotPrototypeKey(key = targetKeys[i]) &&
+          (sourceKeys.indexOf(key) === -1) &&
+          (result[key] = clone(target[key]))
     }
 
     for (i = 0, il = sourceKeys.length; i < il; ++i) {
       isNotPrototypeKey(key = sourceKeys[i]) &&
-        (
-          key in target && (targetKeys.indexOf(key) !== -1 && (result[key] = _deepmerge(target[key], source[key])), true) || // eslint-disable-line no-mixed-operators
-          (result[key] = clone(source[key]))
-        )
+          (
+            key in target && (targetKeys.indexOf(key) !== -1 && (result[key] = _deepmerge(target[key], source[key])), true) || // eslint-disable-line no-mixed-operators
+            (result[key] = clone(source[key]))
+          )
     }
     return result
   }

--- a/index.js
+++ b/index.js
@@ -138,12 +138,16 @@ function deepmergeConstructor (options) {
     }
   }
 
+  const createObject = options && options.nullPrototype === true
+    ? function () { return Object.create(null) }
+    : function () { return {} }
+
   function _deepmergeAll () {
     switch (arguments.length) {
       case 0:
-        return {}
+        return createObject()
       case 1:
-        return clone(arguments[0])
+        return _deepmerge({}, arguments[0])
       case 2:
         return _deepmerge(arguments[0], arguments[1])
     }

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -5,6 +5,7 @@
 // Copyright (c) 2012 - 2022 James Halliday, Josh Duff, and other contributors of deepmerge
 
 const deepmerge = require('../index')({ all: true })
+const deepmergeNull = require('../index')({ all: true, nullPrototype: true })
 const test = require('tap').test
 
 test('return an empty object if first argument is an array with no elements', function (t) {
@@ -64,6 +65,71 @@ test('invoke merge on every item in array without clone should clone all element
   const thirdObject = { c: { f: 'string' } }
 
   const mergedWithoutClone = deepmerge(firstObject, secondObject, thirdObject)
+
+  t.not(mergedWithoutClone.a, firstObject.a)
+  t.not(mergedWithoutClone.b, secondObject.b)
+  t.not(mergedWithoutClone.c, thirdObject.c)
+
+  t.end()
+})
+
+test('return an empty object if first argument is an array with no elements', function (t) {
+  t.same(deepmergeNull(), {})
+  t.end()
+})
+
+test('Work just fine if first argument is an array with least than two elements', function (t) {
+  const actual = deepmergeNull({ example: true })
+  const expected = { example: true }
+  t.same(actual, expected)
+  t.end()
+})
+
+test('execute correctly if options object were not passed', function (t) {
+  t.doesNotThrow(deepmergeNull.bind(null, { example: true }, { another: '123' }))
+  t.end()
+})
+
+test('execute correctly if options object were passed', function (t) {
+  t.doesNotThrow(deepmergeNull.bind(null, { example: true }, { another: '123' }))
+  t.end()
+})
+
+test('invoke merge on every item in array should result with all props', function (t) {
+  const firstObject = { first: true }
+  const secondObject = { second: false }
+  const thirdObject = { third: 123 }
+  const fourthObject = { fourth: 'some string' }
+
+  const mergedObject = deepmergeNull(firstObject, secondObject, thirdObject, fourthObject)
+
+  t.ok(mergedObject.first === true)
+  t.ok(mergedObject.second === false)
+  t.ok(mergedObject.third === 123)
+  t.ok(mergedObject.fourth === 'some string')
+  t.end()
+})
+
+test('invoke merge on every item in array with clone should clone all elements', function (t) {
+  const firstObject = { a: { d: 123 } }
+  const secondObject = { b: { e: true } }
+  const thirdObject = { c: { f: 'string' } }
+
+  const mergedWithClone = deepmergeNull(firstObject, secondObject, thirdObject)
+
+  t.not(mergedWithClone.a, firstObject.a)
+  t.not(mergedWithClone.b, secondObject.b)
+  t.not(mergedWithClone.c, thirdObject.c)
+
+  t.end()
+})
+
+test('invoke merge on every item in array without clone should clone all elements', function (t) {
+  const firstObject = { a: { d: 123 } }
+  const secondObject = { b: { e: true } }
+  const thirdObject = { c: { f: 'string' } }
+
+  const mergedWithoutClone = deepmergeNull(firstObject, secondObject, thirdObject)
 
   t.not(mergedWithoutClone.a, firstObject.a)
   t.not(mergedWithoutClone.b, secondObject.b)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,6 +55,7 @@ type DeepMergeAll<R, T> = First<T> extends never
   : DeepMergeAll<DeepMerge<R, First<T>>, Rest<T>>;
 
 interface Options {
+  nullPrototype?: boolean;
   symbols?: boolean;
   all?: boolean;
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,6 +12,8 @@ expectError(deepmerge({ symbols: 2 }))
 expectError(deepmerge({ symbol: 2 }))
 
 expectAssignable<Function>(deepmerge({ symbols: true }))
+expectAssignable<Function>(deepmerge({ nullPrototype: true }))
+expectAssignable<Function>(deepmerge({ nullPrototype: false }))
 
 expectType<string>(deepmerge()('string', { a: 'string' }).a)
 expectType<string>(deepmerge()(1, { a: 'string' }).a)


### PR DESCRIPTION
If you have Objects were you want to allow also prototype and constructor as valid keys without having the risk of prototype pollution, you have to create Objects with prototype set to null. This PR adds the nullPrototype option. It also improves the performance, by avoiding creating unnecessary intermediary Objects