### PR TITLE
add arrayMerge option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const result = deepmerge([1, 2, 3], [4, 5, 6])
 console.log(result) // [4, 5, 6]
 ```
 
-Example 2: Merge every element of the source-Array with the target-Array
+Example 2: Merge each element of the source-Array with the element at the same index-position of the target-Array.
 
 ```js
 function deepmergeArray(options) {

--- a/README.md
+++ b/README.md
@@ -23,17 +23,40 @@ deepmerge(options)
 
 - `symbols` (`boolean`, optional) - should also merge object-keys which are symbols, default is false
 - `all` (`boolean`, optional) - merges all parameters, default is false
+- `mergeArray` (`function`, optional) - provide a function, which returns a function to add custom array merging function
 
 ```js
-const deepmerge = require('@fastify/deepmegre')()
+const deepmerge = require('@fastify/deepmerge')()
 const result = deepmerge({a: 'value'}, { b: 404 })
 console.log(result) // {a: 'value',  b: 404 }
 ```
 
 ```js
-const deepmerge = require('@fastify/deepmegre')({ all: true })
+const deepmerge = require('@fastify/deepmerge')({ all: true })
 const result = deepmerge({a: 'value'}, { b: 404 }, { a: 404 })
 console.log(result) // {a: 404,  b: 404 }
+```
+
+`mergeArray` has an options-parameter, which is an Object containing the following keys and values 
+
+```typescript
+clone: (value: any) => any;
+isMergeableObject: (value: any) => any;
+deepmerge: DeepMergeFn;
+getKeys: (value: object) => string[];
+```
+
+```js
+function overwriteMerge(options) {
+  const clone = options.clone
+  return function (target, source) {
+    return clone(source)
+  }
+}
+
+const deepmerge = require('@fastify/deepmerge')({ mergeArray: overwriteMerge })
+const result = deepmerge([1, 2, 3], [4, 5, 6])
+console.log(result) // [4, 5, 6]
 ```
 
 ## Benchmarks

--- a/index.js
+++ b/index.js
@@ -75,6 +75,10 @@ function deepmergeConstructor (options) {
     return typeof value !== 'object' || value === null || value instanceof RegExp || value instanceof Date
   }
 
+  const mergeArray = options && typeof options.mergeArray === 'function'
+    ? options.mergeArray({ clone, deepmerge: _deepmerge, getKeys, isMergeableObject })
+    : concatArrays
+
   function clone (entry) {
     return isMergeableObject(entry)
       ? Array.isArray(entry)
@@ -113,7 +117,7 @@ function deepmergeConstructor (options) {
     } else if (isPrimitiveOrBuiltIn(target)) {
       return clone(source)
     } else if (sourceIsArray && targetIsArray) {
-      return concatArrays(target, source)
+      return mergeArray(target, source)
     } else if (sourceIsArray !== targetIsArray) {
       return clone(source)
     } else {

--- a/test/mergearray.test.js
+++ b/test/mergearray.test.js
@@ -1,0 +1,119 @@
+'use strict'
+
+// based on https://github.com/TehShrike/deepmerge/tree/3c39fb376158fa3cfc75250cfc4414064a90f582/test
+// MIT License
+// Copyright (c) 2012 - 2022 James Halliday, Josh Duff, and other contributors of deepmerge
+
+const deepmerge = require('../index')
+const test = require('tap').test
+
+test('all options are set', function (t) {
+  t.plan(4)
+
+  function mergeArray (options) {
+    t.type(options.deepmerge, 'function')
+    t.type(options.isMergeableObject, 'function')
+    t.type(options.getKeys, 'function')
+    t.type(options.clone, 'function')
+    return (a, b) => []
+  }
+  const merge = deepmerge({ mergeArray })
+  merge([], [])
+})
+
+test('cloning works properly', function (t) {
+  t.plan(4)
+
+  function cloneMerge (options) {
+    const clone = options.clone
+    return (a, b) => clone(b)
+  }
+  function referenceMerge () {
+    return (a, b) => b
+  }
+  const a = [1, 2]
+  const b = [3, 4]
+  t.ok(b !== deepmerge({ mergeArray: cloneMerge })(a, b))
+  t.same(deepmerge({ mergeArray: cloneMerge })(a, b), [3, 4])
+  t.ok(b === deepmerge({ mergeArray: referenceMerge })(a, b))
+  t.same(deepmerge({ mergeArray: referenceMerge })(a, b), [3, 4])
+})
+
+test('custom merge array', function (t) {
+  let mergeFunctionCalled = false
+  function overwriteMerge () {
+    return function (target, source) {
+      mergeFunctionCalled = true
+      return source
+    }
+  }
+  const merge = deepmerge({ mergeArray: overwriteMerge })
+  const destination = {
+    someArray: [1, 2],
+    someObject: { what: 'yes' }
+  }
+  const source = {
+    someArray: [1, 2, 3]
+  }
+
+  const actual = merge(destination, source)
+  const expected = {
+    someArray: [1, 2, 3],
+    someObject: { what: 'yes' }
+  }
+
+  t.ok(mergeFunctionCalled)
+  t.strictSame(actual, expected)
+  t.end()
+})
+
+test('merge top-level arrays', function (t) {
+  t.plan(2)
+  const merge = deepmerge({ mergeArray: overwriteMerge })
+
+  function overwriteMerge () {
+    return (a, b) => b
+  }
+  const a = [1, 2]
+  const b = [3, 4]
+  const actual = merge(a, b)
+  const expected = [3, 4]
+
+  t.ok(b === actual)
+  t.strictSame(actual, expected)
+})
+
+test('cloner function is available for merge functions to use', function (t) {
+  t.plan(5)
+  let customMergeWasCalled = false
+  function cloneMerge (options) {
+    const clone = options.clone
+    t.ok(options.clone, 'cloner function is available')
+    return function (target, source) {
+      customMergeWasCalled = true
+      return target.concat(source).map(function (element) {
+        return clone(element)
+      })
+    }
+  }
+
+  const merge = deepmerge({ mergeArray: cloneMerge })
+
+  const src = {
+    key1: ['one', 'three'],
+    key2: ['four']
+  }
+  const target = {
+    key1: ['one', 'two']
+  }
+
+  const expected = {
+    key1: ['one', 'two', 'one', 'three'],
+    key2: ['four']
+  }
+
+  t.strictSame(merge(target, src), expected)
+  t.ok(customMergeWasCalled)
+  t.ok(Array.isArray(merge(target, src).key1))
+  t.ok(Array.isArray(merge(target, src).key2))
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,17 @@ type DeepMergeAll<R, T> = First<T> extends never
   ? R
   : DeepMergeAll<DeepMerge<R, First<T>>, Rest<T>>;
 
+type MergeArrayFnOptions = {
+  clone: (value: any) => any;
+  isMergeableObject: (value: any) => any;
+  deepmerge: DeepMergeFn;
+  getKeys: (value: object) => string[];
+}
+
+type MergeArrayFn = (options: MergeArrayFnOptions) => (target: any[], source: any[]) => any[]
+
 interface Options {
+  mergeArray?: MergeArrayFn;
   symbols?: boolean;
   all?: boolean;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -56,7 +56,7 @@ type DeepMergeAll<R, T> = First<T> extends never
 
 type MergeArrayFnOptions = {
   clone: (value: any) => any;
-  isMergeableObject: (value: any) => any;
+  isMergeableObject: (value: any) => boolean;
   deepmerge: DeepMergeFn;
   getKeys: (value: object) => string[];
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -49,3 +49,22 @@ expectType<string>(deepmerge({all: true, symbols: true})({a: 'a'}, {b: 'a'}).b)
 expectType<number>(deepmerge({all: true, symbols: true})({a: 'a'}, {a: 2}).a)
 expectType<number>(deepmerge({all: true, symbols: true})({a: 'a'}, 2))
 expectType<string>(deepmerge({all: true, symbols: true})({a: 'a'}, 'string'))
+
+expectError(deepmerge({ mergeArray: function () { } }))
+expectError(deepmerge({ mergeArray: function () { return () => 'test' } }))
+deepmerge({
+  mergeArray: function (options) {
+    expectType<(value: any) => any>(options.clone)
+    const clone = options.clone
+    return function (target, source) {
+      return clone(target.concat(source))
+    }
+  }
+})
+deepmerge({
+  mergeArray: function () {
+    return function (target, source) {
+      return source
+    }
+  }
+})


### PR DESCRIPTION
To be able to use @fastify/deepmerge in fluent-json-schema our implementation needs an arrayMerge option. This PR adds it

https://github.com/fastify/fluent-json-schema/blob/master/src/utils.js