### PR TITLE
Fix return type when merging tuples and readonly arrays

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,11 +12,11 @@ type Primitive =
 
 type BuiltIns = Primitive | Date | RegExp;
 
-type MergeTypes<T, U> = T extends Array<infer A1>
-  ? U extends Array<infer A2>
-  ? Array<A1 | A2>
-  : T
-  : U
+type MergeArrays<T, U> = T extends readonly any[]
+  ? U extends readonly any[]
+  ? [...T, ...U]
+  : never
+  : never
 
 type DifferenceKeys<
   T,
@@ -38,8 +38,8 @@ type DeepMergeHelper<
 type DeepMerge<T, U> =
   U extends BuiltIns
   ? U
-  : [T, U] extends [any[], any[]]
-  ? MergeTypes<T, U>
+  : [T, U] extends [readonly any[], readonly any[]]
+  ? MergeArrays<T, U>
   : [T, U] extends [{ [key: string]: unknown }, { [key: string]: unknown }]
   ? DeepMergeHelper<T, U>
   : U

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -34,6 +34,8 @@ expectType<{ a: { a: string, b: string } }>(deepmerge()({ a: { a: { a: 'string' 
 expectType<string>(deepmerge()({ a: [1,2,3,4] }, { a: 'string' }).a)
 expectType<number[]>(deepmerge()({ a: [1,2,3,4] }, { a: [1,2,3,4] }).a)
 expectType<(number|string)[]>(deepmerge()({ a: [1,2,3,4] }, { a: ['a'] }).a)
+expectType<(number|string)[]>(deepmerge()({ a: [1,2,3,4] as readonly number[] }, { a: ['a'] }).a)
+expectType<[1,2,3,4,'a']>(deepmerge()({ a: [1,2,3,4] as const }, { a: ['a'] as const }).a)
 expectType<Array<number>>(deepmerge()({ a: [1] }, { a: [2] }).a)
 expectType<{b: number[]}>(deepmerge()({ a: {b: {}} }, { a: {b: [2]} }).a)
 expectType<{b: Date}>(deepmerge()({ a: {b: {}} }, { a: {b: new Date()} }).a)


### PR DESCRIPTION
Fixes #22

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
