### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/fastify/deepmerge#readme",
   "devDependencies": {
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "tap": "^21.0.0",
     "tape": "^5.7.5",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.