### PR TITLE
docs(readme): use simple english

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const result = deepmerge(target, source)
 console.log(result) // [1, 2, 3, 4, 5, 6]
 ```
 
-To overwrite the default behaviour regarding merging Arrays, you can provide a function to the
+To overwrite the default behavior regarding merging Arrays, you can provide a function to the
 `mergeArray` option of the deepmerge-function. The function provided to `mergeArray`
 gets an options-parameter passed, which is an Object containing the following keys and values.
 
@@ -102,12 +102,12 @@ function deepmergeArray(options) {
   }
 }
 
-// default behaviour
+// default behavior
 const deepmergeConcatArray = require('@fastify/deepmerge')()
 const resultConcatArray = deepmergeConcatArray([{ a: [1, 2, 3 ]}], [{b: [4, 5, 6]}])
 console.log(resultConcatArray) // [ { a: [ 1, 2, 3 ]}, { b: [ 4, 5, 6 ] } ]
 
-// modified behaviour
+// modified behavior
 const deepmergeDeepmergeArray = require('@fastify/deepmerge')({ mergeArray: deepmergeArray })
 const resultDeepmergedArray = deepmergeDeepmergeArray([{ a: [1, 2, 3 ]}], [{b: [4, 5, 6]}])
 console.log(resultDeepmergedArray) // [ { a: [ 1, 2, 3 ], b: [ 4, 5, 6 ] } ]


### PR DESCRIPTION
As much as this pains me, Fastify docs use American English, so we should standardise around that.
This PR replaces British/Traditional English spellings with American/Simple English.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
