### PR TITLE
refactor(index): remove redundant assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,10 +46,10 @@ function deepmergeConstructor (options) {
     const sl = source.length
     let i = 0
     const result = new Array(tl + sl)
-    for (i = 0; i < tl; ++i) {
+    for (i; i < tl; ++i) {
       result[i] = clone(target[i])
     }
-    for (i = 0; i < sl; ++i) {
+    for (i; i < sl; ++i) {
       result[i + tl] = clone(source[i])
     }
     return result

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function deepmergeConstructor (options) {
     for (i; i < tl; ++i) {
       result[i] = clone(target[i])
     }
-    for (i= 0; i < sl; ++i) {
+    for (i = 0; i < sl; ++i) {
       result[i + tl] = clone(source[i])
     }
     return result

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function deepmergeConstructor (options) {
     let i = 0
     const il = value.length
     const result = new Array(il)
-    for (i = 0; i < il; ++i) {
+    for (i; i < il; ++i) {
       result[i] = clone(value[i])
     }
     return result

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function deepmergeConstructor (options) {
     for (i; i < tl; ++i) {
       result[i] = clone(target[i])
     }
-    for (i; i < sl; ++i) {
+    for (i= 0; i < sl; ++i) {
       result[i + tl] = clone(source[i])
     }
     return result


### PR DESCRIPTION
`i` is already assigned the value `0` on line 19 and on 49 in another function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
