### PR TITLE
types(DeepMergeAllFn): refine DeepMergeAllFn return type when handling lists with deep partial objects

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,14 +1,104 @@
 type DeepMergeFn = <T1, T2>(target: T1, source: T2) => DeepMerge<T1, T2>
-type DeepMergeAllFn = <T extends Array<any>>(...targets: T) => DeepMergeAll<{}, T>
+type DeepMergeAllFn = <T extends Array<any>>(
+  ...targets: T
+) => AllRecordsMatchDeepPartial<T> extends true ? First<T> : DeepMergeAll<{}, T>
 
-type Primitive =
-  | null
-  | undefined
-  | string
-  | number
-  | boolean
-  | symbol
-  | bigint
+/**
+ * A utility type that recursively makes all properties of an object optional.
+ * If a property is itself a nested object, DeepPartial is applied to it as well.
+ *
+ * @example
+ * type User = {
+ *   name: string;
+ *   address: {
+ *     city: string;
+ *     zip: number;
+ *   };
+ * };
+ *
+ * type PartialUser = DeepPartial<User>;
+ * // Resulting type:
+ * // {
+ * //   name?: string;
+ * //   address?: {
+ * //     city?: string;
+ * //     zip?: number;
+ * //   };
+ * // }
+ */
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown> ? DeepPartial<T[K]> : Partial<T[K]>
+}
+
+/**
+ * A type utility that checks if T is a record (an object with string keys and any values).
+ * If T is a record, it evaluates to true; otherwise, it evaluates to false.
+ *
+ * @example
+ * type Test1 = IsRecord<{ key: string }>; // true
+ * type Test2 = IsRecord<string>; // false
+ */
+type IsRecord<T> = T extends Record<string, any> ? true : false
+
+/**
+ * A type utility that verifies whether all elements in a tuple or array T are records.
+ * It recursively checks each element in the array.
+ *
+ * @example
+ * type Test1 = AllRecords<[{ a: number }, { b: string }]>; // true
+ * type Test2 = AllRecords<[{ a: number }, string]>; // false
+ * type Test3 = AllRecords<[]>; // true (an empty array passes the check)
+ */
+type AllRecords<T extends Array<any>> = T extends [infer F, ...infer R]
+  ? IsRecord<F> extends true
+    ? R extends [] // If no more elements, return true
+      ? true
+      : AllRecords<R> // Recursively check the remaining elements
+    : false
+  : true
+
+/**
+ * A type utility that checks whether all elements in an array T are deep partials of the first element.
+ *
+ * @example
+ * type User = {
+ *   name: string;
+ *   age: number;
+ * };
+ *
+ * type Test1 = AllDeepPartials<[User, { name?: string }]>; // true
+ * type Test2 = AllDeepPartials<[User, { name: string; extra: boolean }]>; // false
+ * type Test3 = AllDeepPartials<[]>; // false (empty array fails the check)
+ */
+type AllDeepPartials<T extends Array<any>> = T extends [infer First, ...infer Rest]
+  ? Rest extends { [index: number]: DeepPartial<First> } // Check if all following objects are DeepPartial<First>
+    ? true
+    : false
+  : false
+
+/**
+ * A type utility that combines the checks of AllRecords and AllDeepPartials.
+ * First, it verifies if all elements in the array are records.
+ * Then, it ensures all elements are deep partials of the first element.
+ *
+ * @example
+ * type User = {
+ *   name: string;
+ *   age: number;
+ * };
+ *
+ * type Test1 = AllRecordsMatchDeepPartial<[User, { name?: string }]>; // true
+ * type Test2 = AllRecordsMatchDeepPartial<[User, { name: string; extra: boolean }]>; // false
+ * type Test3 = AllRecordsMatchDeepPartial<[string, { name?: string }]>; // false
+ * type Test4 = AllRecordsMatchDeepPartial<[]>; // false (empty array fails the check)
+ */
+type AllRecordsMatchDeepPartial<T extends Array<any>> = AllRecords<T> extends true
+  ? AllDeepPartials<T> extends true
+    ? true
+    : false
+  : false
+
+type Primitive = null | undefined | string | number | boolean | symbol | bigint
 
 type BuiltIns = Primitive | Date | RegExp
 
@@ -23,7 +113,7 @@ type DifferenceKeys<
   U,
   T0 = Omit<T, keyof U> & Omit<U, keyof T>,
   T1 = { [K in keyof T0]: T0[K] }
-  > = T1
+> = T1
 
 type IntersectionKeys<T, U> = Omit<T | U, keyof DifferenceKeys<T, U>>
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -70,3 +70,35 @@ deepmerge({
     }
   }
 })
+
+type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
+
+type StrictObject = {
+  a: string
+  b: number
+  c: {
+    d: string
+  }
+}
+
+const obj1: StrictObject = {
+  a: '1',
+  b: 2,
+  c: {
+    d: '3',
+  },
+}
+
+const obj2: DeepPartial<StrictObject> = {
+  b: 4,
+}
+
+const obj3: DeepPartial<StrictObject> = {
+  c: { d: '5' },
+}
+
+expectType<StrictObject>(deepmerge({ all: true })(obj1, obj2, obj3))

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -71,17 +71,19 @@ deepmerge({
   }
 })
 
-type DeepPartial<T> = T extends object
-  ? {
-      [P in keyof T]?: DeepPartial<T[P]>
-    }
-  : T
-
 type StrictObject = {
   a: string
   b: number
   c: {
     d: string
+  }
+}
+
+type DeepOptionalObject = {
+  a?: string
+  b?: number
+  c?: {
+    d?: string
   }
 }
 
@@ -93,11 +95,11 @@ const obj1: StrictObject = {
   },
 }
 
-const obj2: DeepPartial<StrictObject> = {
+const obj2: DeepOptionalObject = {
   b: 4,
 }
 
-const obj3: DeepPartial<StrictObject> = {
+const obj3: DeepOptionalObject = {
   c: { d: '5' },
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Summary

This PR fixes an issue in the `DeepMergeAllFn` type where the returned type did not correctly match the type of the first object in scenarios where a list of objects was passed, and the subsequent objects were deep partial versions of the first.

### Problem

Previously, when DeepMergeAllFn was called with a list of objects, where all objects from the second onward were deep partial versions of the first object, the return type defaulted to DeepMergeAll<{}, T> instead of preserving the type of the first object. This led to incorrect typings and made the function’s behavior less predictable.

The screenshot below shows the error before the changes in this PR: the `deepmerge` function would return a partial object type.
<img width="1043" alt="Screenshot 2025-01-17 at 16 18 30" src="https://github.com/user-attachments/assets/627b08fa-8728-47e5-aff4-1349461897ef" />

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
