### PR TITLE
fix(types): export function definition types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,7 +72,7 @@ interface Options {
 type DeepmergeConstructor = typeof deepmerge
 
 declare namespace deepmerge {
-  export { Options }
+  export { Options, DeepMergeFn, DeepMergeAllFn }
   export const deepmerge: DeepmergeConstructor
   export { deepmerge as default }
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,8 @@
 import { expectAssignable, expectError, expectType } from 'tsd'
-import { deepmerge } from '.'
+import { deepmerge, type DeepMergeFn, type DeepMergeAllFn } from '.'
+
+expectAssignable<Function>(deepmerge())
+expectType<DeepMergeFn>(deepmerge())
 
 expectType<string>(deepmerge()({ a: 'a' }, { b: 'b' }).a)
 expectType<string>(deepmerge()({ a: 'a' }, { b: 'b' }).b)
@@ -12,6 +15,7 @@ expectError(deepmerge({ symbols: 2 }))
 expectError(deepmerge({ symbol: 2 }))
 
 expectAssignable<Function>(deepmerge({ symbols: true }))
+expectType<DeepMergeFn>(deepmerge({ symbols: true }))
 
 expectType<string>(deepmerge()('string', { a: 'string' }).a)
 expectType<string>(deepmerge()(1, { a: 'string' }).a)
@@ -44,7 +48,9 @@ expectType<Date>(deepmerge()({ a: { b: {} } }, new Date()))
 expectType<Map<any, any>>(deepmerge()({ a: { b: {} } }, new Map()))
 
 expectAssignable<Function>(deepmerge({ all: true }))
+expectType<DeepMergeAllFn>(deepmerge({ all: true }))
 expectAssignable<Function>(deepmerge({ all: true, symbols: true }))
+expectType<DeepMergeAllFn>(deepmerge({ all: true, symbols: true }))
 expectType<string>(deepmerge({ all: true, symbols: true })({ a: 'a' }).a)
 expectType<string>(deepmerge({ all: true, symbols: true })({ a: 'a' }, { b: 'a' }).a)
 expectType<string>(deepmerge({ all: true, symbols: true })({ a: 'a' }, { b: 'a' }).b)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes https://github.com/fastify/deepmerge/issues/12.

While working on one of my private projects, I encountered the same issue described in https://github.com/fastify/deepmerge/issues/12.
I’m using deepmerge with TypeScript, and when building my project, I experienced [the heap out of memory error](https://github.com/fastify/deepmerge/issues/12#issuecomment-1273196966) mentioned in that issue.

To resolve this, I tried exporting `DeepMergeFn` and `DeepMergeAllFn` directly from the `@fastify/deepmerge` folder in `node_modules`, which successfully fixed the problem.

Alternatively, if the issue persists, you can leverage these types as follows:
```ts
const deepmergeAll: DeepMergeAllFn = deepmerge({ all: true });
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
