### PR TITLE
feat: add `onlyDefinedProperties` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ deepmerge(options)
 - `mergeArray` (`function`, optional) - provide a function, which returns a function to add custom array merging function
 - `cloneProtoObject` (`function`, optional) - provide a function, which must return a clone of the object with the prototype of the object
 - `isMergeableObject` (`function`, optional) - provide a function, which must return true if the object should be merged, default is `isMergeableObject` from this module
-- `skipUndefinedSources` (`boolean`, optional) - if `true`, properties with `undefined` in the source will not overwrite existing values from the target, default is `false`
+- `onlyDefinedProperties` (`boolean`, optional) - if `true`, properties with `undefined` in the source will not overwrite existing values from the target, default is `false`
 
 ```js
 const deepmerge = require('@fastify/deepmerge')()
@@ -42,10 +42,10 @@ const result = deepmerge({a: 'value'}, { b: 404 }, { a: 404 })
 console.log(result) // {a: 404,  b: 404 }
 ```
 
-Example with `skipUndefinedSources` option:
+Example with `onlyDefinedProperties` option:
 
 ```js
-const deepmerge = require('@fastify/deepmerge')({ skipUndefinedSources: true })
+const deepmerge = require('@fastify/deepmerge')({ onlyDefinedProperties: true })
 const result = deepmerge({ a: 1, b: null }, { a: undefined, b: undefined })
 console.log(result) // { a: 1, b: null }
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ deepmerge(options)
 - `mergeArray` (`function`, optional) - provide a function, which returns a function to add custom array merging function
 - `cloneProtoObject` (`function`, optional) - provide a function, which must return a clone of the object with the prototype of the object
 - `isMergeableObject` (`function`, optional) - provide a function, which must return true if the object should be merged, default is `isMergeableObject` from this module
+- `skipUndefinedSources` (`boolean`, optional) - if `true`, properties with `undefined` in the source will not overwrite existing values from the target, default is `false`
 
 ```js
 const deepmerge = require('@fastify/deepmerge')()
@@ -39,6 +40,14 @@ console.log(result) // {a: 'value',  b: 404 }
 const deepmerge = require('@fastify/deepmerge')({ all: true })
 const result = deepmerge({a: 'value'}, { b: 404 }, { a: 404 })
 console.log(result) // {a: 404,  b: 404 }
+```
+
+Example with `skipUndefinedSources` option:
+
+```js
+const deepmerge = require('@fastify/deepmerge')({ skipUndefinedSources: true })
+const result = deepmerge({ a: 1, b: null }, { a: undefined, b: undefined })
+console.log(result) // { a: 1, b: null }
 ```
 
 #### mergeArray

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function deepmergeConstructor (options) {
     ? options.isMergeableObject
     : defaultIsMergeableObjectFactory()
 
-  const skipUndefinedSources = options?.skipUndefinedSources === true
+  const onlyDefinedProperties = options?.onlyDefinedProperties === true
 
   function isPrimitive (value) {
     return typeof value !== 'object' || value === null
@@ -126,7 +126,7 @@ function deepmergeConstructor (options) {
           }
         }
       } else {
-        if (skipUndefinedSources && typeof source[key] === 'undefined') {
+        if (onlyDefinedProperties && typeof source[key] === 'undefined') {
           continue
         }
         result[key] = clone(source[key])
@@ -136,10 +136,10 @@ function deepmergeConstructor (options) {
   }
 
   function _deepmerge (target, source) {
-    if (skipUndefinedSources && typeof source === 'undefined') {
+    if (onlyDefinedProperties && typeof source === 'undefined') {
       return clone(target)
     }
-    
+
     const sourceIsArray = Array.isArray(source)
     const targetIsArray = Array.isArray(target)
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,8 @@ function deepmergeConstructor (options) {
     ? options.isMergeableObject
     : defaultIsMergeableObjectFactory()
 
+  const skipUndefinedSources = options?.skipUndefinedSources === true
+
   function isPrimitive (value) {
     return typeof value !== 'object' || value === null
   }
@@ -124,6 +126,9 @@ function deepmergeConstructor (options) {
           }
         }
       } else {
+        if (skipUndefinedSources && typeof source[key] === 'undefined') {
+          continue
+        }
         result[key] = clone(source[key])
       }
     }
@@ -133,6 +138,10 @@ function deepmergeConstructor (options) {
   function _deepmerge (target, source) {
     const sourceIsArray = Array.isArray(source)
     const targetIsArray = Array.isArray(target)
+
+    if (skipUndefinedSources && typeof source === 'undefined') {
+      return clone(target)
+    }
 
     if (isPrimitive(source)) {
       return source

--- a/index.js
+++ b/index.js
@@ -136,12 +136,12 @@ function deepmergeConstructor (options) {
   }
 
   function _deepmerge (target, source) {
-    const sourceIsArray = Array.isArray(source)
-    const targetIsArray = Array.isArray(target)
-
     if (skipUndefinedSources && typeof source === 'undefined') {
       return clone(target)
     }
+    
+    const sourceIsArray = Array.isArray(source)
+    const targetIsArray = Array.isArray(target)
 
     if (isPrimitive(source)) {
       return source

--- a/test/skipundefined.test.js
+++ b/test/skipundefined.test.js
@@ -1,0 +1,57 @@
+"use strict"
+
+const test = require('tape').test
+const deepmergeDefault = require("../index")
+
+test("default overwrites with undefined", function (t) {
+	const merge = deepmergeDefault()
+	const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
+	t.same(actual, { a: undefined, b: undefined, c: undefined })
+	t.end()
+})
+
+test("skipUndefinedSources=true preserves target when source undefined (flat)", function (t) {
+	const merge = deepmergeDefault({ skipUndefinedSources: true })
+	const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
+	t.same(actual, { a: 1, b: null, c: [1] })
+	t.end()
+})
+
+test("skipUndefinedSources=true preserves nested properties", function (t) {
+	const merge = deepmergeDefault({ skipUndefinedSources: true })
+	const target = { a: { x: 1, y: 2 }, b: { z: 3 } }
+	const source = { a: { x: undefined }, b: undefined }
+	const actual = merge(target, source)
+	t.same(actual, { a: { x: 1, y: 2 }, b: { z: 3 } })
+	t.end()
+})
+
+test("skipUndefinedSources=true skips new undefined properties (root)", function (t) {
+	const merge = deepmergeDefault({ skipUndefinedSources: true })
+	const actual = merge({}, { a: undefined })
+	t.equal(Object.hasOwn(actual, 'a'), false)
+	t.same(actual, {})
+	t.end()
+})
+
+test("skipUndefinedSources=true skips new undefined properties (nested)", function (t) {
+	const merge = deepmergeDefault({ skipUndefinedSources: true })
+	const actual = merge({ b: {} }, { b: { c: undefined } })
+	t.equal(Object.hasOwn(actual.b, 'c'), false)
+	t.same(actual, { b: {} })
+	t.end()
+})
+
+test("skipUndefinedSources=true still adds new defined properties", function (t) {
+	const merge = deepmergeDefault({ skipUndefinedSources: true })
+	const actual = merge({ a: 1 }, { b: 2 })
+	t.same(actual, { a: 1, b: 2 })
+	t.end()
+})
+
+test("skipUndefinedSources=true does not change array merging for defined values", function (t) {
+	const merge = deepmergeDefault({ skipUndefinedSources: true })
+	const actual = merge([1, 2], [3])
+	t.same(actual, [1, 2, 3])
+	t.end()
+})

--- a/test/skipundefined.test.js
+++ b/test/skipundefined.test.js
@@ -1,57 +1,57 @@
-"use strict"
+'use strict'
 
 const test = require('tape').test
-const deepmergeDefault = require("../index")
+const deepmergeDefault = require('../index')
 
-test("default overwrites with undefined", function (t) {
-	const merge = deepmergeDefault()
-	const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
-	t.same(actual, { a: undefined, b: undefined, c: undefined })
-	t.end()
+test('default overwrites with undefined', function (t) {
+  const merge = deepmergeDefault()
+  const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
+  t.same(actual, { a: undefined, b: undefined, c: undefined })
+  t.end()
 })
 
-test("skipUndefinedSources=true preserves target when source undefined (flat)", function (t) {
-	const merge = deepmergeDefault({ skipUndefinedSources: true })
-	const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
-	t.same(actual, { a: 1, b: null, c: [1] })
-	t.end()
+test('skipUndefinedSources=true preserves target when source undefined (flat)', function (t) {
+  const merge = deepmergeDefault({ skipUndefinedSources: true })
+  const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
+  t.same(actual, { a: 1, b: null, c: [1] })
+  t.end()
 })
 
-test("skipUndefinedSources=true preserves nested properties", function (t) {
-	const merge = deepmergeDefault({ skipUndefinedSources: true })
-	const target = { a: { x: 1, y: 2 }, b: { z: 3 } }
-	const source = { a: { x: undefined }, b: undefined }
-	const actual = merge(target, source)
-	t.same(actual, { a: { x: 1, y: 2 }, b: { z: 3 } })
-	t.end()
+test('skipUndefinedSources=true preserves nested properties', function (t) {
+  const merge = deepmergeDefault({ skipUndefinedSources: true })
+  const target = { a: { x: 1, y: 2 }, b: { z: 3 } }
+  const source = { a: { x: undefined }, b: undefined }
+  const actual = merge(target, source)
+  t.same(actual, { a: { x: 1, y: 2 }, b: { z: 3 } })
+  t.end()
 })
 
-test("skipUndefinedSources=true skips new undefined properties (root)", function (t) {
-	const merge = deepmergeDefault({ skipUndefinedSources: true })
-	const actual = merge({}, { a: undefined })
-	t.equal(Object.hasOwn(actual, 'a'), false)
-	t.same(actual, {})
-	t.end()
+test('skipUndefinedSources=true skips new undefined properties (root)', function (t) {
+  const merge = deepmergeDefault({ skipUndefinedSources: true })
+  const actual = merge({}, { a: undefined })
+  t.equal(Object.hasOwn(actual, 'a'), false)
+  t.same(actual, {})
+  t.end()
 })
 
-test("skipUndefinedSources=true skips new undefined properties (nested)", function (t) {
-	const merge = deepmergeDefault({ skipUndefinedSources: true })
-	const actual = merge({ b: {} }, { b: { c: undefined } })
-	t.equal(Object.hasOwn(actual.b, 'c'), false)
-	t.same(actual, { b: {} })
-	t.end()
+test('skipUndefinedSources=true skips new undefined properties (nested)', function (t) {
+  const merge = deepmergeDefault({ skipUndefinedSources: true })
+  const actual = merge({ b: {} }, { b: { c: undefined } })
+  t.equal(Object.hasOwn(actual.b, 'c'), false)
+  t.same(actual, { b: {} })
+  t.end()
 })
 
-test("skipUndefinedSources=true still adds new defined properties", function (t) {
-	const merge = deepmergeDefault({ skipUndefinedSources: true })
-	const actual = merge({ a: 1 }, { b: 2 })
-	t.same(actual, { a: 1, b: 2 })
-	t.end()
+test('skipUndefinedSources=true still adds new defined properties', function (t) {
+  const merge = deepmergeDefault({ skipUndefinedSources: true })
+  const actual = merge({ a: 1 }, { b: 2 })
+  t.same(actual, { a: 1, b: 2 })
+  t.end()
 })
 
-test("skipUndefinedSources=true does not change array merging for defined values", function (t) {
-	const merge = deepmergeDefault({ skipUndefinedSources: true })
-	const actual = merge([1, 2], [3])
-	t.same(actual, [1, 2, 3])
-	t.end()
+test('skipUndefinedSources=true does not change array merging for defined values', function (t) {
+  const merge = deepmergeDefault({ skipUndefinedSources: true })
+  const actual = merge([1, 2], [3])
+  t.same(actual, [1, 2, 3])
+  t.end()
 })

--- a/test/skipundefined.test.js
+++ b/test/skipundefined.test.js
@@ -10,15 +10,15 @@ test('default overwrites with undefined', function (t) {
   t.end()
 })
 
-test('skipUndefinedSources=true preserves target when source undefined (flat)', function (t) {
-  const merge = deepmergeDefault({ skipUndefinedSources: true })
+test('onlyDefinedProperties=true preserves target when source undefined (flat)', function (t) {
+  const merge = deepmergeDefault({ onlyDefinedProperties: true })
   const actual = merge({ a: 1, b: null, c: [1] }, { a: undefined, b: undefined, c: undefined })
   t.same(actual, { a: 1, b: null, c: [1] })
   t.end()
 })
 
-test('skipUndefinedSources=true preserves nested properties', function (t) {
-  const merge = deepmergeDefault({ skipUndefinedSources: true })
+test('onlyDefinedProperties=true preserves nested properties', function (t) {
+  const merge = deepmergeDefault({ onlyDefinedProperties: true })
   const target = { a: { x: 1, y: 2 }, b: { z: 3 } }
   const source = { a: { x: undefined }, b: undefined }
   const actual = merge(target, source)
@@ -26,31 +26,31 @@ test('skipUndefinedSources=true preserves nested properties', function (t) {
   t.end()
 })
 
-test('skipUndefinedSources=true skips new undefined properties (root)', function (t) {
-  const merge = deepmergeDefault({ skipUndefinedSources: true })
+test('onlyDefinedProperties=true skips new undefined properties (root)', function (t) {
+  const merge = deepmergeDefault({ onlyDefinedProperties: true })
   const actual = merge({}, { a: undefined })
   t.equal(Object.hasOwn(actual, 'a'), false)
   t.same(actual, {})
   t.end()
 })
 
-test('skipUndefinedSources=true skips new undefined properties (nested)', function (t) {
-  const merge = deepmergeDefault({ skipUndefinedSources: true })
+test('onlyDefinedProperties=true skips new undefined properties (nested)', function (t) {
+  const merge = deepmergeDefault({ onlyDefinedProperties: true })
   const actual = merge({ b: {} }, { b: { c: undefined } })
   t.equal(Object.hasOwn(actual.b, 'c'), false)
   t.same(actual, { b: {} })
   t.end()
 })
 
-test('skipUndefinedSources=true still adds new defined properties', function (t) {
-  const merge = deepmergeDefault({ skipUndefinedSources: true })
+test('onlyDefinedProperties=true still adds new defined properties', function (t) {
+  const merge = deepmergeDefault({ onlyDefinedProperties: true })
   const actual = merge({ a: 1 }, { b: 2 })
   t.same(actual, { a: 1, b: 2 })
   t.end()
 })
 
-test('skipUndefinedSources=true does not change array merging for defined values', function (t) {
-  const merge = deepmergeDefault({ skipUndefinedSources: true })
+test('onlyDefinedProperties=true does not change array merging for defined values', function (t) {
+  const merge = deepmergeDefault({ onlyDefinedProperties: true })
   const actual = merge([1, 2], [3])
   t.same(actual, [1, 2, 3])
   t.end()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,10 +78,10 @@ interface Options {
   symbols?: boolean;
   all?: boolean;
   /**
-   * If true, do not overwrite existing values with undefined values from source.
+   * If true, ignore undefined values from source and keep existing target values.
    * Defaults to false.
    */
-  skipUndefinedSources?: boolean;
+  onlyDefinedProperties?: boolean;
 }
 
 type DeepmergeConstructor = typeof deepmerge

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,6 +68,7 @@ type MergeArrayFnOptions = {
  * @returns the resulting clone (can also return the object itself if you do not want clone but replace).
  */
 type CloneProtoObjectFn = (value: any) => any
+
 type MergeArrayFn = (options: MergeArrayFnOptions) => (target: any[], source: any[]) => any[]
 
 interface Options {
@@ -76,6 +77,11 @@ interface Options {
   isMergeableObject?: (value: any) => boolean;
   symbols?: boolean;
   all?: boolean;
+  /**
+   * If true, do not overwrite existing values with undefined values from source.
+   * Defaults to false.
+   */
+  skipUndefinedSources?: boolean;
 }
 
 type DeepmergeConstructor = typeof deepmerge
@@ -89,6 +95,7 @@ declare namespace deepmerge {
 }
 
 declare function deepmerge (options: Options & { all: true }): DeepMergeAllFn
+
 declare function deepmerge (options?: Options): DeepMergeFn
 
 export = deepmerge


### PR DESCRIPTION
Adds a way to prevent undefined source values from applying to target. See https://github.com/fastify/deepmerge/issues/72

Adding a new `skipUndefinedSources` option (but defaulting to false) makes the external API non-breaking.

Let me know if anything can be improved.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
